### PR TITLE
Replace `watch` module with webpack functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^4.0.2",
-    "lodash.camelcase": "^4.3.0",
-    "watch": "^1.0.2"
+    "lodash.camelcase": "^4.3.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/src/dot-index-plugin.js
+++ b/src/dot-index-plugin.js
@@ -1,34 +1,32 @@
-const path  = require('path')
-const { createMonitor } = require('watch')
 const createDotIndexFiles = require('./utils/create-dot-index-files')
 
-function DotIndexPlugin (options={}) {
+function DotIndexPlugin(options = {}) {
   this.options = options
   this.initialized = false
 }
 
-DotIndexPlugin.prototype.apply = function (compiler) {
+// In webpack v4, contextDependencies is a Set
+function addContextDependency(compilation, dependency) {
+  compilation.contextDependencies.add(dependency)
+}
+
+DotIndexPlugin.prototype.apply = function(compiler) {
   const { path: rootPath, ...options } = this.options
   if (!rootPath) throw new Error('DotIndexPlugin requires "path" option')
-  function recompile () {
-    return compiler.run(() => {})
+  // Add root path to contextDependencies
+  // This will make webpack watch the entire directory
+  compiler.hooks.afterEmit.tapAsync('DotIndexPlugin', (compilation, cb) => {
+    addContextDependency(compilation, rootPath)
+    cb()
+  })
+  // Before compilation, build dot index files
+  function onRun(_compilation, cb) {
+    createDotIndexFiles(rootPath, options)
+    cb()
   }
-  compiler.hooks.watchRun.tapAsync('DotIndexPlugin', (compilation, callback) => {
-    createDotIndexFiles(rootPath, options)
-    // Only initialize once
-    if (this.initialized) return callback()
-    createMonitor(rootPath, monitor => {
-      monitor.files[path.join(rootPath, '*.js')]
-      monitor.on('created', recompile)
-      monitor.on('removed', recompile)
-      this.initialized = true
-      callback()
-    })
-  })
-  compiler.hooks.run.tapAsync('DotIndexPlugin', (compilation, callback) => {
-    createDotIndexFiles(rootPath, options)
-    callback()
-  })
+  // Hook into both normal and watch mode
+  compiler.hooks.run.tapAsync('DotIndexPlugin', onRun)
+  compiler.hooks.watchRun.tapAsync('DotIndexPlugin', onRun)
 }
 
 module.exports = DotIndexPlugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,13 +5269,6 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-watch@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-1.0.2.tgz#340a717bde765726fa0aa07d721e0147a551df0c"
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
-
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"


### PR DESCRIPTION
Resolves #11 (potentially). @chawes13 can you try this out locally?

Along with linking, you'll need to remove `/\.index\.js` from the ignored files array in webpack dev server.