### PR TITLE
Upgrade lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^4.0.2",
-    "lodash.camelcase": "^4.17.21",
-    "lodash.update": "^4.17.21"
+    "lodash": "^4.17.21"
   },
   "jest": {
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^4.0.2",
-    "lodash.camelcase": "^4.3.0",
-    "lodash.update": "^4.3.0"
+    "lodash.camelcase": "^4.17.21",
+    "lodash.update": "^4.17.21"
   },
   "jest": {
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dot-index-webpack-plugin",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "",
   "main": "src/index.js",
   "bin": {
@@ -22,9 +22,9 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.0",
     "@launchpadlab/babel-preset": "^1.0.0",
     "@launchpadlab/eslint-config": "^2.1.0",
-    "@babel/core": "^7.12.0",
     "babel-eslint": "^8.0.1",
     "babel-loader": "^9.1.0",
     "eslint": "^4.10.0",

--- a/src/dot-index-plugin.js
+++ b/src/dot-index-plugin.js
@@ -1,5 +1,5 @@
 const createDotIndexFiles = require('./utils/create-dot-index-files')
-const update = require('lodash.update')
+const { update } = require('lodash')
 
 function DotIndexPlugin(options = {}) {
   this.options = options

--- a/src/utils/create-index-file-content.js
+++ b/src/utils/create-index-file-content.js
@@ -1,4 +1,4 @@
-const camelcase = require('lodash.camelcase')
+const { camelCase } = require('lodash')
 
 function stripExtension (fileName) {
   return fileName.split('.')[0]
@@ -9,7 +9,7 @@ function isKebabCase (fileName) {
 }
 
 function defaultFormatExports (fileName, rootPath) {
-  return isKebabCase(fileName) ? camelcase(fileName) : fileName
+  return isKebabCase(fileName) ? camelCase(fileName) : fileName
 }
 
 function createIndexFileContent (files=[], rootPath, { formatExports=defaultFormatExports }={}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,10 +3897,6 @@ lodash._topath@^3.0.0:
   dependencies:
     lodash.isarray "^3.0.0"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -3916,10 +3912,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.update@^4.3.0:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/lodash.update/-/lodash.update-4.10.2.tgz#9da9985cf06646f5226bca8e276d58bee0db8796"
-  integrity sha1-namYXPBmRvUia8qOJ21YvuDbh5Y=
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"


### PR DESCRIPTION
- Resolves lodash dependency issue on projects that use this package
- Switches from per-method packages to the latest whole version of the lodash package: 4.17.21
  - Per method packages didn't appear to be updated as recently and I found this resource that recommended against that anyway: https://medium.com/swlh/dont-use-lodash-per-method-packages-507409a87959